### PR TITLE
Fix for arbitrary code execution

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,22 @@
 const execSync = require('child_process').execSync
 
 function getProcesses (command) {
+  const processesObject = {}
+
+  /* Sanitizes the input command by limiting the command name 
+   * to specific characters.
+   */
+  const regex = /[^A-Za-z0-9 .\-_]+/g
+  
+  if (command.match(regex))
+  {
+    return processesObject;
+  }
+
   const lsofOutput = execSync(`lsof -i TCP -P -n | grep '${command}\\s.*:[0-9]* (LISTEN)' | cat`, {encoding: 'utf-8'})
     .toString()
     .split('\n')
-  const processesObject = {}
+
   lsofOutput.forEach((lsofString) => {
     if (lsofString) {
       const currentProcessObject = createProcessObjectFromLsof(lsofString)


### PR DESCRIPTION
PR improving the command consumption by this nodejs plugin. Executing commands by directly inputting whatever user provides is always a dangerous precedent. After going through various sources where this same exploit scenarios have been discovered, the safest way would be to use `execFileSync()` instead, but I couldn't find a way to pipe all those commands as the author of this project intended to do.
Hence, I've used regex to limit the command name which can be run. As of now, it should accept every known process name. That is because this regex is compiled by looking at the restrictions for unix file names.